### PR TITLE
feat(api): add ApiClientService and integrate with HomeComponent

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -3,7 +3,10 @@ import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import { HttpErrorInterceptor } from './core/http-error-interceptor.service';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideRouter(routes), provideAnimationsAsync()]
+  providers: [provideRouter(routes), provideAnimationsAsync(), provideHttpClient(withInterceptorsFromDi()), { provide: HTTP_INTERCEPTORS, useClass: HttpErrorInterceptor, multi: true },]
 };

--- a/src/app/core/api-client.service.ts
+++ b/src/app/core/api-client.service.ts
@@ -1,0 +1,41 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { environment } from '../../environments/environment';
+
+type Query = Record<string, string | number | boolean | null | undefined>;
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ApiClientService {
+  private http = inject(HttpClient);
+  private base = environment.apiBaseUrl;
+
+  private withBase(path: string) {
+    
+    return `${this.base.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
+  }
+
+  private headers(json = true) {
+    return json ? new HttpHeaders({ 'Content-Type': 'application/json' }) : undefined;
+  }
+
+  get<T>(path: string, query?: Query) {
+    const params = query ? new HttpParams({ fromObject: query as any }) : undefined;
+    return this.http.get<T>(this.withBase(path), { params });
+  }
+
+  post<T>(path: string, body: unknown) {
+    return this.http.post<T>(this.withBase(path), body, { headers: this.headers() });
+  }
+
+  put<T>(path: string, body: unknown) {
+    return this.http.put<T>(this.withBase(path), body, { headers: this.headers() });
+  }
+
+  delete<T>(path: string) {
+    return this.http.delete<T>(this.withBase(path));
+  }
+}
+
+

--- a/src/app/core/http-error-interceptor.service.ts
+++ b/src/app/core/http-error-interceptor.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Observable, tap } from 'rxjs';
+
+@Injectable()
+export class HttpErrorInterceptor implements HttpInterceptor {
+  intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    return next.handle(req).pipe(
+      tap({ error: (err) => console.error('[HTTP]', req.method, req.url, err) })
+    );
+  }
+}

--- a/src/app/features/dashboard/pages/home/home.component.html
+++ b/src/app/features/dashboard/pages/home/home.component.html
@@ -1,1 +1,2 @@
 <p>home works!</p>
+<p><strong>API status:</strong> {{ apiStatus }}</p>

--- a/src/app/features/dashboard/pages/home/home.component.ts
+++ b/src/app/features/dashboard/pages/home/home.component.ts
@@ -1,12 +1,22 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ApiClientService } from '../../../../core/api-client.service';
 
 @Component({
   selector: 'app-home',
   standalone: true,
-  imports: [],
+  imports: [CommonModule],
   templateUrl: './home.component.html',
-  styleUrl: './home.component.scss'
+  styleUrls: ['./home.component.scss']
 })
 export class HomeComponent {
-
+  private api = inject(ApiClientService);
+  apiStatus = "checking...";
+  
+  ngOnInit() {
+    this.api.get<{ message: string }>('/health').subscribe({
+      next: (r) => this.apiStatus = r.message,
+      error: () => this.apiStatus = 'API unavailable',
+    });
+  }
 }

--- a/src/app/features/dashboard/services/health.service.ts
+++ b/src/app/features/dashboard/services/health.service.ts
@@ -1,0 +1,12 @@
+import { Injectable, inject } from '@angular/core';
+import { ApiClientService } from '../../../core/api-client.service';
+
+type HealthResponse = { message: string };
+
+@Injectable({ providedIn: 'root' })
+export class HealthService {
+  private api = inject(ApiClientService);
+  ping() {                       // GET /api/health
+    return this.api.get<HealthResponse>('/health');
+  }
+}


### PR DESCRIPTION
1. Added **ApiClientService** with `get/post/put/delete`.
2. Optional error interceptor for console logging.
3. Home page now calls `/api/health` and shows status.
4. **Base URL** comes from `environment.apiBaseUrl`.

### How to test:

**Run backend** (`npm run dev`) → ensure `http://localhost:5000/api/health` returns JSON.

Run frontend (`ng serv`e).

Open http://localhost:4200/home → see “API status: Backend is running!”.