### PR TITLE
feat(shared-ui): reusable DataTable, EntityFormDialog, ConfirmDialog components and integrated into Teachers, Subjects, Loads

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -100,6 +100,11 @@
               "@angular/material/prebuilt-themes/indigo-pink.css",
               "src/styles.scss"
             ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "src/styles"
+              ]
+            },
             "scripts": []
           }
         }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -11,6 +11,7 @@ import { BreakpointObserver } from '@angular/cdk/layout';
 import { MatSidenav } from '@angular/material/sidenav';
 import { environment } from '../environments/environment';
 import { AuthService } from './features/auth/services/auth.service';
+import { MatDialogModule } from '@angular/material/dialog';
 
 @Component({
   selector: 'app-root',
@@ -23,7 +24,9 @@ import { AuthService } from './features/auth/services/auth.service';
     MatSidenavModule,
     MatListModule,
     MatIconModule,
-    MatButtonModule,],
+    MatButtonModule,
+    MatDialogModule
+  ],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,14 +1,20 @@
 import { Routes } from '@angular/router';
 import { HomeComponent } from './features/dashboard/pages/home/home.component';
-// import { authGuard } from './features/auth/guards/auth.guard';
+import { TeachersComponent } from './features/teachers/pages/teachers/teachers.component';
+import { authGuard } from './features/auth/guards/auth.guard';
 import { guestGuard } from './features/auth/guards/guest.guard';
 import { LoginComponent } from './features/auth/pages/login/login.component';
 import { RegisterComponent } from './features/auth/pages/register/register.component';
+import { SubjectsComponent } from './features/subjects/pages/subjects/subjects.component';
+import { LoadsComponent } from './features/loads/pages/loads/loads.component';
 
 export const routes: Routes = [
     { path: '', pathMatch: 'full', redirectTo: 'home' },
     { path: 'home', component: HomeComponent },
     { path: 'auth/login', component: LoginComponent, canActivate: [guestGuard] },
     { path: 'auth/register', component: RegisterComponent, canActivate: [guestGuard] },
+    { path: 'lecturers', component: TeachersComponent, canActivate: [authGuard] },
+    { path: 'subjects', component: SubjectsComponent, canActivate: [authGuard] },
+    { path: 'loads', component: LoadsComponent, canActivate: [authGuard] },
     { path: '**', redirectTo: 'home' },
 ];

--- a/src/app/features/auth/services/auth.service.ts
+++ b/src/app/features/auth/services/auth.service.ts
@@ -49,27 +49,31 @@ export class AuthService {
     return this.hasToken();
   }
 
-  /** Login -> server returns token; save it and mark as authenticated */
   login(data: LoginDto) {
     return this.api.post<LoginResponse>('/auth/login', data).pipe(
       tap((res) => {
+        // console.log('[AuthService] Login response:', res);
+
         localStorage.setItem(TOKEN_KEY, res.token);
+        // console.log('[AuthService] Token saved to localStorage:', res.token);
+
         this._isAuth$.next(true);
       })
     );
   }
 
-  /** Register -> server returns only {success,message}; DO NOT store token here */
   register(data: RegisterDto) {
     const payload = {
       username: `${data.firstName ?? ''} ${data.lastName ?? ''}`.trim(),
       email: data.email,
       password: data.password,
     };
+    // console.log('[AuthService] Register payload:', payload);
     return this.api.post<RegisterResponse>('/auth/register', payload);
   }
 
   logout() {
+    // console.log('[AuthService] Logging out, removing token');
     localStorage.removeItem(TOKEN_KEY);
     this._isAuth$.next(false);
     this.router.navigate(['/home']);

--- a/src/app/features/loads/pages/loads/loads.component.html
+++ b/src/app/features/loads/pages/loads/loads.component.html
@@ -1,0 +1,24 @@
+<h2 class="page-title">Teaching Loads</h2>
+
+<div class="toolbar">
+  <button mat-flat-button color="primary" (click)="openCreateDialog()">
+    + Add Load
+  </button>
+</div>
+
+<app-data-table
+  [columns]="columns"
+  [data]="rows"
+  [length]="total"
+  [pageIndex]="pageIndex"
+  [pageSize]="pageSize"
+  [pageSizeOptions]="[5, 10, 25]"
+  [loading]="loading"
+  [showActions]="true"
+  (rowClick)="onRowClick($event)"
+  (edit)="onEdit($event)"
+  (remove)="onDelete($event)"
+  (page)="onPage($event)"
+  (sort)="onSort($event)"
+>
+</app-data-table>

--- a/src/app/features/loads/pages/loads/loads.component.scss
+++ b/src/app/features/loads/pages/loads/loads.component.scss
@@ -1,0 +1,15 @@
+.page-title {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 16px 0;
+}
+
+.toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 12px;
+
+  button {
+    font-weight: 500;
+  }
+}

--- a/src/app/features/loads/pages/loads/loads.component.spec.ts
+++ b/src/app/features/loads/pages/loads/loads.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LoadsComponent } from './loads.component';
+
+describe('LoadsComponent', () => {
+  let component: LoadsComponent;
+  let fixture: ComponentFixture<LoadsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LoadsComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(LoadsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/loads/pages/loads/loads.component.ts
+++ b/src/app/features/loads/pages/loads/loads.component.ts
@@ -1,0 +1,137 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DataTableComponent, DataTableColumn } from '../../../../shared/components/data-table/data-table.component';
+import { LoadsService, Load } from '../../services/loads.service';
+import { PageEvent } from '@angular/material/paginator';
+import { Sort } from '@angular/material/sort';
+import { MatDialog } from '@angular/material/dialog';
+import { EntityFormDialogComponent } from '../../../../shared/components/entity-form-dialog/entity-form-dialog.component';
+import { ConfirmDialogComponent } from '../../../../shared/components/confirm-dialog/confirm-dialog.component';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Component({
+  standalone: true,
+  selector: 'app-loads',
+  imports: [CommonModule, DataTableComponent],
+  templateUrl: './loads.component.html',
+  styleUrls: ['./loads.component.scss'],
+})
+export class LoadsComponent implements OnInit {
+  rows: Load[] = [];
+  total = 0;
+  pageIndex = 0;
+  pageSize = 10;
+  loading = false;
+
+  columns: DataTableColumn[] = [
+    { 
+      key: 'teacher', 
+      header: 'Teacher', 
+      cell: (row) => row.teacher ? `${row.teacher.firstName} ${row.teacher.lastName}` : '' 
+    },
+    { 
+      key: 'subject', 
+      header: 'Subject', 
+      cell: (row) => row.subject?.name || '' 
+    },
+    { key: 'group', header: 'Group' },
+    { key: 'type', header: 'Type' }
+  ];
+
+  constructor(
+    private loadsService: LoadsService,
+    private dialog: MatDialog,
+    private snackBar: MatSnackBar
+  ) {}
+
+  ngOnInit() {
+    this.loadLoads();
+  }
+
+  loadLoads() {
+    this.loading = true;
+    this.loadsService.getAll().subscribe({
+      next: (data) => {
+        this.rows = data;
+        this.total = data.length;
+        this.loading = false;
+      },
+      error: () => {
+        this.snackBar.open('Failed to load teaching loads', 'Close', { duration: 3000 });
+        this.loading = false;
+      }
+    });
+  }
+
+  onEdit(row: Load) {
+    const dialogRef = this.dialog.open(EntityFormDialogComponent, {
+      width: '500px',
+      data: { entity: { _id: row._id }, type: 'load', existing: this.rows }
+    });
+
+    dialogRef.afterClosed().subscribe((updated: Load | null) => {
+      if (updated) {
+        this.loadsService.update(row._id, updated).subscribe({
+          next: () => {
+            this.snackBar.open('Teaching load updated successfully!', 'Close', { duration: 3000 });
+            this.loadLoads();
+          },
+          error: () => {
+            this.snackBar.open('Failed to update load.', 'Close', { duration: 3000 });
+          }
+        });
+      }
+    });
+  }
+
+  onDelete(row: Load) {
+    const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+      width: '360px',
+      data: {
+        title: 'Confirm Deletion',
+        message: `Delete load for "${row.teacher}" - "${row.subject}"? This action cannot be undone.`,
+      },
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.loadsService.delete(row._id).subscribe({
+          next: () => {
+            this.snackBar.open('Load deleted successfully!', 'Close', { duration: 3000 });
+            this.loadLoads();
+          },
+          error: () => {
+            this.snackBar.open('Failed to delete load.', 'Close', { duration: 3000 });
+          }
+        });
+      }
+    });
+  }
+
+  openCreateDialog() {
+    const dialogRef = this.dialog.open(EntityFormDialogComponent, {
+      width: '400px',
+      data: { entity: null, type: 'load', existing: this.rows }
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.loadsService.create(result).subscribe(() => {
+          this.loadLoads();
+        });
+      }
+    });
+  }
+
+  onRowClick(row: Load) {
+    console.log('row clicked', row);
+  }
+
+  onPage(event: PageEvent) {
+    console.log('pagination event', event);
+  }
+
+  onSort(event: Sort) {
+    console.log('sort event', event);
+  }
+}

--- a/src/app/features/loads/services/loads.service.spec.ts
+++ b/src/app/features/loads/services/loads.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { LoadsService } from './loads.service';
+
+describe('LoadsService', () => {
+  let service: LoadsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(LoadsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/features/loads/services/loads.service.ts
+++ b/src/app/features/loads/services/loads.service.ts
@@ -1,0 +1,36 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiClientService } from '../../../core/api-client.service';
+
+export interface Load {
+  _id: string;
+  teacher: string;
+  subject: string;
+  group: string;
+  type: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class LoadsService {
+  private api = inject(ApiClientService);
+
+  getAll(): Observable<Load[]> {
+    return this.api.get<Load[]>('/loads');
+  }
+
+  getById(id: string): Observable<Load> {
+    return this.api.get<Load>(`/loads/${id}`);
+  }
+
+  create(data: Omit<Load, '_id'>): Observable<Load> {
+    return this.api.post<Load>('/loads', data);
+  }
+
+  update(id: string, data: Partial<Load>): Observable<Load> {
+    return this.api.put<Load>(`/loads/${id}`, data);
+  }
+
+  delete(id: string): Observable<void> {
+    return this.api.delete<void>(`/loads/${id}`);
+  }
+}

--- a/src/app/features/subjects/pages/subjects/subjects.component.html
+++ b/src/app/features/subjects/pages/subjects/subjects.component.html
@@ -1,0 +1,24 @@
+<h2 class="page-title">Subjects</h2>
+
+<div class="toolbar">
+  <button mat-flat-button color="primary" (click)="openCreateDialog()">
+    + Add Subject
+  </button>
+</div>
+
+<app-data-table
+  [columns]="columns"
+  [data]="rows"
+  [length]="total"
+  [pageIndex]="pageIndex"
+  [pageSize]="pageSize"
+  [pageSizeOptions]="[5, 10, 25]"
+  [loading]="loading"
+  [showActions]="true"
+  (rowClick)="onRowClick($event)"
+  (edit)="onEdit($event)"
+  (remove)="onDelete($event)"
+  (page)="onPage($event)"
+  (sort)="onSort($event)"
+>
+</app-data-table>

--- a/src/app/features/subjects/pages/subjects/subjects.component.scss
+++ b/src/app/features/subjects/pages/subjects/subjects.component.scss
@@ -1,0 +1,36 @@
+.page-title {
+  font-size: 20px;
+  font-weight: 600;
+  margin-bottom: 16px;
+  color: #333;
+}
+
+.toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 12px;
+
+  button {
+    font-weight: 500;
+  }
+}
+
+::ng-deep app-data-table {
+  mat-table {
+    background: #fff;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow:
+      0 4px 10px rgba(0, 0, 0, 0.05),
+      0 1px 3px rgba(0, 0, 0, 0.08);
+  }
+
+  mat-header-cell {
+    font-weight: 600;
+    background: #f5f6fa;
+  }
+
+  mat-cell, mat-header-cell {
+    padding: 12px;
+  }
+}

--- a/src/app/features/subjects/pages/subjects/subjects.component.ts
+++ b/src/app/features/subjects/pages/subjects/subjects.component.ts
@@ -1,0 +1,135 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DataTableComponent, DataTableColumn } from '../../../../shared/components/data-table/data-table.component';
+import { SubjectsService, Subject } from '../../services/subjects.service';
+import { PageEvent } from '@angular/material/paginator';
+import { Sort } from '@angular/material/sort';
+import { MatDialog } from '@angular/material/dialog';
+import { EntityFormDialogComponent } from '../../../../shared/components/entity-form-dialog/entity-form-dialog.component';
+import { ConfirmDialogComponent } from '../../../../shared/components/confirm-dialog/confirm-dialog.component';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Component({
+  standalone: true,
+  selector: 'app-subjects',
+  imports: [CommonModule, DataTableComponent],
+  templateUrl: './subjects.component.html',
+  styleUrls: ['./subjects.component.scss'],
+})
+export class SubjectsComponent implements OnInit {
+  rows: Subject[] = [];
+  total = 0;
+  pageIndex = 0;
+  pageSize = 10;
+  loading = false;
+
+  columns: DataTableColumn[] = [
+    { key: 'name', header: 'Name' },
+    { key: 'hours', header: 'Hours' }
+  ];
+
+  constructor(
+    private subjectsService: SubjectsService,
+    private dialog: MatDialog,
+    private snackBar: MatSnackBar
+  ) {}
+
+  ngOnInit() {
+    this.loadSubjects();
+  }
+
+  loadSubjects() {
+    this.loading = true;
+    this.subjectsService.getAll().subscribe({
+      next: (data) => {
+        this.rows = data;
+        this.total = data.length;
+        this.loading = false;
+      },
+      error: (err) => {
+        this.snackBar.open('Failed to load subjects', 'Close', { duration: 3000 });
+        this.loading = false;
+      }
+    });
+  }
+
+  onEdit(row: Subject) {
+    const dialogRef = this.dialog.open(EntityFormDialogComponent, {
+      width: '500px',
+      data: {
+        entity: { _id: row._id },
+        type: 'subject',
+        existing: this.rows
+      }
+    });
+
+    dialogRef.afterClosed().subscribe((updated: Subject | null) => {
+      if (updated) {
+        this.subjectsService.update(row._id, updated).subscribe({
+          next: () => {
+            this.snackBar.open('Subject updated successfully!', 'Close', { duration: 3000 });
+            this.loadSubjects();
+          },
+          error: () => {
+            this.snackBar.open('Failed to update subject.', 'Close', { duration: 3000 });
+          }
+        });
+      }
+    });
+  }
+
+  onDelete(row: Subject) {
+    const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+      width: '360px',
+      data: {
+        title: 'Confirm Deletion',
+        message: `Delete subject "${row.name}"? This action cannot be undone.`,
+      },
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.subjectsService.delete(row._id).subscribe({
+          next: () => {
+            this.snackBar.open('Subject deleted successfully!', 'Close', { duration: 3000 });
+            this.loadSubjects();
+          },
+          error: () => {
+            this.snackBar.open('Failed to delete subject.', 'Close', { duration: 3000 });
+          }
+        });
+      }
+    });
+  }
+
+  openCreateDialog() {
+    const dialogRef = this.dialog.open(EntityFormDialogComponent, {
+      width: '400px',
+      data: {
+        entity: null,
+        type: 'subject',
+        existing: this.rows
+      }
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.subjectsService.create(result).subscribe(() => {
+          this.loadSubjects();
+        });
+      }
+    });
+  }
+
+  onRowClick(row: Subject) {
+    console.log('row clicked', row);
+  }
+
+  onPage(event: PageEvent) {
+    console.log('pagination event', event);
+  }
+
+  onSort(event: Sort) {
+    console.log('sort event', event);
+  }
+}

--- a/src/app/features/subjects/services/subjects.service.ts
+++ b/src/app/features/subjects/services/subjects.service.ts
@@ -1,0 +1,34 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiClientService } from '../../../core/api-client.service';
+
+export interface Subject {
+  _id: string;
+  name: string;
+  hours: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class SubjectsService {
+  private api = inject(ApiClientService);
+
+  getAll(): Observable<Subject[]> {
+    return this.api.get<Subject[]>('/subjects');
+  }
+
+  getById(id: string): Observable<Subject> {
+    return this.api.get<Subject>(`/subjects/${id}`);
+  }
+
+  create(data: Omit<Subject, '_id'>): Observable<Subject> {
+    return this.api.post<Subject>('/subjects', data);
+  }
+
+  update(id: string, data: Partial<Subject>): Observable<Subject> {
+    return this.api.put<Subject>(`/subjects/${id}`, data);
+  }
+
+  delete(id: string): Observable<void> {
+    return this.api.delete<void>(`/subjects/${id}`);
+  }
+}

--- a/src/app/features/teachers/pages/teachers/teachers.component.html
+++ b/src/app/features/teachers/pages/teachers/teachers.component.html
@@ -1,0 +1,24 @@
+<h2 class="page-title">Lecturers</h2>
+
+<div class="toolbar">
+  <button mat-flat-button color="primary" (click)="openCreateDialog()">
+    + Add Lecturer
+  </button>
+</div>
+
+<app-data-table
+  [columns]="columns"
+  [data]="rows"
+  [length]="total"
+  [pageIndex]="pageIndex"
+  [pageSize]="pageSize"
+  [pageSizeOptions]="[5, 10, 25]"
+  [loading]="loading"
+  [showActions]="true"
+  (rowClick)="onRowClick($event)"
+  (edit)="onEdit($event)"
+  (remove)="onDelete($event)"
+  (page)="onPage($event)"
+  (sort)="onSort($event)"
+>
+</app-data-table>

--- a/src/app/features/teachers/pages/teachers/teachers.component.scss
+++ b/src/app/features/teachers/pages/teachers/teachers.component.scss
@@ -1,0 +1,14 @@
+.page-title {
+  margin: 0 0 12px;
+  font-weight: 600;
+}
+
+.toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 12px;
+
+  button {
+    font-weight: 500;
+  }
+}

--- a/src/app/features/teachers/pages/teachers/teachers.component.ts
+++ b/src/app/features/teachers/pages/teachers/teachers.component.ts
@@ -1,0 +1,138 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  DataTableComponent,
+  DataTableColumn,
+} from '../../../../shared/components/data-table/data-table.component';
+import { TeachersService, Teacher } from '../../services/teachers.service';
+import { PageEvent } from '@angular/material/paginator';
+import { Sort } from '@angular/material/sort';
+import { MatDialog } from '@angular/material/dialog';
+import { EntityFormDialogComponent } from '../../../../shared/components/entity-form-dialog/entity-form-dialog.component';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { ConfirmDialogComponent } from '../../../../shared/components/confirm-dialog/confirm-dialog.component';
+
+@Component({
+  standalone: true,
+  selector: 'app-teachers',
+  imports: [CommonModule, DataTableComponent, EntityFormDialogComponent, ConfirmDialogComponent],
+  templateUrl: './teachers.component.html',
+  styleUrls: ['./teachers.component.scss'],
+})
+export class TeachersComponent implements OnInit {
+
+  rows: Teacher[] = [];
+  total = 0;
+  pageIndex = 0;
+  pageSize = 10;
+  loading = false;
+
+  columns: DataTableColumn[] = [
+    { key: 'firstName', header: 'First Name' },
+    { key: 'lastName', header: 'Last Name' },
+    { key: 'middleName', header: 'Middle Name' },
+    { key: 'degree', header: 'Degree' },
+    { key: 'position', header: 'Position' },
+    { key: 'experience', header: 'Experience (years)' }
+  ];
+
+  constructor(private dialog: MatDialog, 
+    private snackBar: MatSnackBar, 
+    private teachersService: TeachersService
+  ) {}
+
+  ngOnInit() {
+    this.loadTeachers();
+  }
+
+  loadTeachers() {
+    this.loading = true;
+    this.teachersService.getAll().subscribe({
+      next: (teachers) => {
+        this.rows = teachers;
+        this.total = teachers.length;
+        this.loading = false;
+      },
+      error: (err) => {
+        console.error('Failed to load teachers', err);
+        this.loading = false;
+      }
+    });
+  }
+
+  onEdit(row: Teacher) {
+    const dialogRef = this.dialog.open(EntityFormDialogComponent, {
+      width: '500px',
+      data: {
+        entity: { _id: row._id },
+        existing: this.rows,
+        type: 'teacher'
+      }
+    });
+
+    dialogRef.afterClosed().subscribe((updated: Teacher | null) => {
+      if (updated) {
+        this.teachersService.update(row._id, updated).subscribe({
+          next: () => {
+            this.snackBar.open('Teacher updated successfully!', 'Close', { duration: 3000 });
+            this.loadTeachers();
+          },
+          error: () => {
+            this.snackBar.open('Failed to update teacher.', 'Close', { duration: 3000 });
+          }
+        });
+      }
+    });
+  }
+
+  onDelete(row: Teacher) {
+    const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+      width: '360px',
+      data: {
+        title: 'Confirm Deletion',
+        message: `Delete "${row.firstName} ${row.lastName}"? This action cannot be undone.`,
+      },
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.teachersService.delete(row._id).subscribe({
+          next: () => {
+            this.snackBar.open('Teacher deleted successfully!', 'Close', { duration: 3000 });
+            this.loadTeachers();
+          },
+          error: () => {
+            this.snackBar.open('Failed to delete teacher.', 'Close', { duration: 3000 });
+          }
+        });
+      }
+    });
+  }
+
+  onRowClick(row: Teacher) {
+    console.log('row clicked', row);
+  }
+
+  onPage(event: PageEvent) {
+    console.log('pagination event', event);
+  }
+
+  onSort(event: Sort) {
+    console.log('sort event', event);
+  }
+
+  openCreateDialog() {
+    const dialogRef = this.dialog.open(EntityFormDialogComponent, {
+      width: '400px',
+      data: { entity: null, existing: this.rows, type: 'teacher' }
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.teachersService.create(result).subscribe(() => {
+          this.loadTeachers();
+        });
+      }
+    });
+  }
+}

--- a/src/app/features/teachers/services/teachers.service.ts
+++ b/src/app/features/teachers/services/teachers.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiClientService } from '../../../core/api-client.service';
+
+export interface Teacher {
+  _id: string;
+  firstName: string;
+  lastName: string;
+  middleName?: string;
+  degree: string;
+  position: string;
+  experience: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class TeachersService {
+  private api = inject(ApiClientService);
+
+  getAll(): Observable<Teacher[]> {
+    return this.api.get<Teacher[]>('/teachers');
+  }
+
+  getById(id: string): Observable<Teacher> {
+    return this.api.get<Teacher>(`/teachers/${id}`);
+  }
+
+  create(data: Omit<Teacher, '_id'>): Observable<Teacher> {
+    return this.api.post<Teacher>('/teachers', data);
+  }
+
+  update(id: string, data: Partial<Teacher>): Observable<Teacher> {
+    return this.api.put<Teacher>(`/teachers/${id}`, data);
+  }
+
+  delete(id: string): Observable<void> {
+    return this.api.delete<void>(`/teachers/${id}`);
+  }
+}

--- a/src/app/shared/components/confirm-dialog/confirm-dialog.component.html
+++ b/src/app/shared/components/confirm-dialog/confirm-dialog.component.html
@@ -1,0 +1,10 @@
+<h2 mat-dialog-title>{{ data.title || "Confirm" }}</h2>
+
+<mat-dialog-content>
+  <p>{{ data.message || "Are you sure?" }}</p>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button (click)="onCancel()">Cancel</button>
+  <button mat-flat-button color="warn" (click)="onConfirm()">Delete</button>
+</mat-dialog-actions>

--- a/src/app/shared/components/confirm-dialog/confirm-dialog.component.scss
+++ b/src/app/shared/components/confirm-dialog/confirm-dialog.component.scss
@@ -1,0 +1,31 @@
+.dialog-form-container {
+  max-width: 560px;
+  margin: 0 auto;
+  padding: 24px;
+  border-radius: 16px;
+  background: #fff;
+  box-shadow:
+    0 8px 24px rgba(0,0,0,.08),
+    0 2px 8px rgba(0,0,0,.04);
+
+  display: grid;
+  gap: 16px;
+
+  .full-width {
+    width: 100%;
+  }
+
+  .dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    margin-top: 12px;
+  }
+}
+
+@media (max-width: 640px) {
+  .dialog-form-container {
+    margin: 12px;
+    padding: 16px;
+  }
+}

--- a/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
+++ b/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
@@ -1,0 +1,26 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  standalone: true,
+  selector: 'app-confirm-dialog',
+  imports: [CommonModule, MatDialogModule, MatButtonModule],
+  templateUrl: './confirm-dialog.component.html',
+  styleUrls: ['./confirm-dialog.component.scss']
+})
+export class ConfirmDialogComponent {
+  constructor(
+    private dialogRef: MatDialogRef<ConfirmDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: { title?: string; message?: string }
+  ) {}
+
+  onConfirm() {
+    this.dialogRef.close(true);
+  }
+
+  onCancel() {
+    this.dialogRef.close(false);
+  }
+}

--- a/src/app/shared/components/data-table/data-table.component.html
+++ b/src/app/shared/components/data-table/data-table.component.html
@@ -1,0 +1,52 @@
+<div class="data-table-container">
+  <mat-progress-bar *ngIf="loading" mode="indeterminate"></mat-progress-bar>
+
+  <table
+    mat-table
+    [dataSource]="data"
+    matSort
+    (matSortChange)="onSort($event)"
+    class="mat-elevation-z1"
+  >
+    <ng-container [matColumnDef]="col.key" *ngFor="let col of columns">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>
+        {{ col.header }}
+      </th>
+      <td mat-cell *matCellDef="let row">{{ cellValue(col, row) }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="actions" *ngIf="showActions">
+      <th mat-header-cell *matHeaderCellDef>Дії</th>
+      <td mat-cell *matCellDef="let row">
+        <button mat-icon-button color="primary" (click)="onEdit(row)">
+          <mat-icon>edit</mat-icon>
+        </button>
+        <button mat-icon-button color="warn" (click)="onDelete(row)">
+          <mat-icon>delete</mat-icon>
+        </button>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr
+      mat-row
+      *matRowDef="let row; columns: displayedColumns"
+      (click)="onRowClick(row)"
+    ></tr>
+
+    <tr class="no-data-row" *ngIf="!loading && data.length === 0">
+      <td [attr.colspan]="displayedColumns.length" class="no-data">
+        Немає даних для відображення.
+      </td>
+    </tr>
+  </table>
+
+  <mat-paginator
+    [length]="length"
+    [pageSize]="pageSize"
+    [pageIndex]="pageIndex"
+    [pageSizeOptions]="pageSizeOptions"
+    (page)="onPage($event)"
+    *ngIf="!loading"
+  ></mat-paginator>
+</div>

--- a/src/app/shared/components/data-table/data-table.component.scss
+++ b/src/app/shared/components/data-table/data-table.component.scss
@@ -1,0 +1,44 @@
+.data-table {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 8px;
+  min-height: 240px;
+}
+
+.table-wrap {
+  overflow: auto;
+  border-radius: 10px;
+  border: 1px solid rgba(0,0,0,.08);
+  background: #fff;
+}
+
+table {
+  width: 100%;
+}
+
+th.mat-mdc-header-cell {
+  background: #fafafa;
+  font-weight: 600;
+}
+
+td.mat-mdc-cell,
+th.mat-mdc-header-cell {
+  padding: 10px 16px;
+  white-space: nowrap;
+}
+
+.actions-col {
+  width: 106px;
+  text-align: right;
+
+  button + button {
+    margin-left: 6px;
+  }
+}
+
+tr.empty td {
+  text-align: center;
+  color: #666;
+  padding: 24px 12px;
+  font-style: italic;
+}

--- a/src/app/shared/components/data-table/data-table.component.ts
+++ b/src/app/shared/components/data-table/data-table.component.ts
@@ -1,0 +1,105 @@
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  ViewChild,
+  OnChanges,
+  SimpleChanges,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTable, MatTableModule } from '@angular/material/table';
+import { MatPaginator, MatPaginatorModule, PageEvent } from '@angular/material/paginator';
+import { MatSort, MatSortModule, Sort } from '@angular/material/sort';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+
+export type DataTableColumn = {
+  key: string;
+  header: string;
+  cell?: (row: any) => string | number | boolean | null | undefined;
+  width?: string;
+};
+
+@Component({
+  selector: 'app-data-table',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatTableModule,
+    MatPaginatorModule,
+    MatSortModule,
+    MatIconModule,
+    MatButtonModule,
+    MatProgressBarModule,
+  ],
+  templateUrl: './data-table.component.html',
+  styleUrls: ['./data-table.component.scss'],
+})
+export class DataTableComponent implements OnChanges {
+  @Input() columns: DataTableColumn[] = [];
+  @Input() data: any[] = [];
+  @Input() showActions = false;
+  @Input() loading = false;
+  @Input() length = 0;
+  @Input() pageIndex = 0;
+  @Input() pageSize = 10;
+  @Input() pageSizeOptions: number[] = [5, 10, 25, 50];
+
+  @Output() rowClick = new EventEmitter<any>();
+  @Output() page = new EventEmitter<PageEvent>();
+  @Output() sort = new EventEmitter<Sort>();
+  @Output() edit = new EventEmitter<any>();
+  @Output() remove = new EventEmitter<any>();
+
+  displayedColumns: string[] = [];
+
+  @ViewChild(MatTable) table?: MatTable<any>;
+  @ViewChild(MatPaginator) paginator?: MatPaginator;
+  @ViewChild(MatSort) sortRef?: MatSort;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (this.columns && Array.isArray(this.columns) && this.columns.length > 0) {
+      this.displayedColumns = this.columns.map((c) => c.key);
+      if (this.showActions) {
+        this.displayedColumns.push('actions');
+      }
+
+      queueMicrotask(() => this.table?.renderRows());
+    }
+  }
+
+  onRowClick(row: any) {
+    this.rowClick.emit(row);
+  }
+
+  onEdit(row: any) {
+    this.edit.emit(row);
+  }
+
+  onDelete(row: any) {
+    this.remove.emit(row);
+  }
+
+  onPage(e: PageEvent) {
+    this.page.emit(e);
+  }
+
+  onSort(e: Sort) {
+    this.sort.emit(e);
+  }
+
+  cellValue(col: DataTableColumn, row: any) {
+    if (col.cell) return col.cell(row);
+
+    if (col.key.includes('.')) {
+      return col.key.split('.').reduce((acc, part) => acc?.[part], row) ?? '';
+    }
+
+    const v = row?.[col.key];
+    return v === null || v === undefined ? '' : String(v);
+  }
+
+  trackByIndex = (_: number, item: any) => item;
+}

--- a/src/app/shared/components/entity-form-dialog/entity-form-dialog.component.html
+++ b/src/app/shared/components/entity-form-dialog/entity-form-dialog.component.html
@@ -1,0 +1,105 @@
+<h2 mat-dialog-title>
+  {{ isEditMode ? "Edit" : "Create" }}
+  {{
+    data.type === "teacher"
+      ? "Teacher"
+      : data.type === "subject"
+      ? "Subject"
+      : "Teaching Load"
+  }}
+</h2>
+
+<form [formGroup]="form" (ngSubmit)="onSubmit()" mat-dialog-content>
+  <!-- Teacher form -->
+  <ng-container *ngIf="data.type === 'teacher'">
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>First Name</mat-label>
+      <input matInput formControlName="firstName" />
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Last Name</mat-label>
+      <input matInput formControlName="lastName" />
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Middle Name</mat-label>
+      <input matInput formControlName="middleName" />
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Degree</mat-label>
+      <input matInput formControlName="degree" />
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Position</mat-label>
+      <input matInput formControlName="position" />
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Experience (years)</mat-label>
+      <input matInput type="number" formControlName="experience" />
+    </mat-form-field>
+  </ng-container>
+
+  <!-- Subject form -->
+  <ng-container *ngIf="data.type === 'subject'">
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Subject Name</mat-label>
+      <input matInput formControlName="name" />
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Hours</mat-label>
+      <input matInput type="number" formControlName="hours" />
+    </mat-form-field>
+  </ng-container>
+
+  <!-- Load form -->
+  <ng-container *ngIf="data.type === 'load'">
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Teacher</mat-label>
+      <mat-select formControlName="teacher">
+        <mat-option *ngFor="let t of teachers" [value]="t._id">
+          {{ t.firstName }} {{ t.lastName }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Subject</mat-label>
+      <mat-select formControlName="subject">
+        <mat-option *ngFor="let s of subjects" [value]="s._id">
+          {{ s.name }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Group</mat-label>
+      <input matInput formControlName="group" />
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Type</mat-label>
+      <mat-select formControlName="type">
+        <mat-option value="lecture">Lecture</mat-option>
+        <mat-option value="practice">Practice</mat-option>
+      </mat-select>
+    </mat-form-field>
+  </ng-container>
+
+  <!-- Actions -->
+  <div class="dialog-actions" mat-dialog-actions>
+    <button mat-button type="button" (click)="onCancel()">Cancel</button>
+    <button
+      mat-flat-button
+      color="primary"
+      type="submit"
+      [disabled]="form.invalid || loading"
+    >
+      {{ isEditMode ? "Update" : "Create" }}
+    </button>
+  </div>
+</form>

--- a/src/app/shared/components/entity-form-dialog/entity-form-dialog.component.scss
+++ b/src/app/shared/components/entity-form-dialog/entity-form-dialog.component.scss
@@ -1,0 +1,26 @@
+@use '../../../../styles/shared-ui.mixins' as *;
+
+.auth-title {
+  @include auth-title;
+}
+
+.auth-card {
+  @include auth-card;
+}
+
+.row-2 {
+  @include row-2;
+}
+
+.form-error {
+  @include form-error;
+}
+
+.w-100 {
+  width: 100%;
+}
+
+.submit-btn {
+  width: 100%;
+  height: 44px;
+}

--- a/src/app/shared/components/entity-form-dialog/entity-form-dialog.component.ts
+++ b/src/app/shared/components/entity-form-dialog/entity-form-dialog.component.ts
@@ -1,0 +1,195 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+
+import { TeachersService } from '../../../features/teachers/services/teachers.service';
+import { SubjectsService } from '../../../features/subjects/services/subjects.service';
+import { LoadsService } from '../../../features/loads/services/loads.service';
+
+@Component({
+  standalone: true,
+  selector: 'app-entity-form-dialog',
+  templateUrl: './entity-form-dialog.component.html',
+  styleUrls: ['./entity-form-dialog.component.scss'],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatSnackBarModule,
+    MatSelectModule,
+  ]
+})
+export class EntityFormDialogComponent {
+  form: FormGroup;
+  isEditMode = false;
+  loading = false;
+  teachers: any[] = [];
+  subjects: any[] = [];
+
+  constructor(
+    private dialogRef: MatDialogRef<EntityFormDialogComponent>,
+    @Inject(MAT_DIALOG_DATA)
+    public data: {
+      entity?: any;
+      existing?: any[];
+      type: 'teacher' | 'subject' | 'load';
+    },
+    private fb: FormBuilder,
+    private snackBar: MatSnackBar,
+    private teachersService: TeachersService,
+    private subjectsService: SubjectsService,
+    private loadsService: LoadsService
+  ) {
+    this.isEditMode = !!data.entity;
+
+    this.form = this.fb.group(this.getFormConfig());
+
+    if (this.data.type === 'load') {
+      this.loadTeachersAndSubjects();
+    }
+
+    if (this.isEditMode && data.entity && Object.keys(data.entity).length === 1 && data.entity._id) {
+      this.loadEntityById(data.entity._id);
+    } else if (this.isEditMode && data.entity) {
+      this.form.patchValue(data.entity);
+    }
+  }
+
+  private loadTeachersAndSubjects() {
+    this.teachersService.getAll().subscribe({
+      next: (res) => (this.teachers = res),
+      error: () => this.snackBar.open('Failed to load teachers', 'Close', { duration: 3000 })
+    });
+
+    this.subjectsService.getAll().subscribe({
+      next: (res) => (this.subjects = res),
+      error: () => this.snackBar.open('Failed to load subjects', 'Close', { duration: 3000 })
+    });
+  }
+
+  getFormConfig() {
+    if (this.data.type === 'teacher') {
+      return {
+        firstName: ['', Validators.required],
+        lastName: ['', Validators.required],
+        middleName: [''],
+        degree: ['', Validators.required],
+        position: ['', Validators.required],
+        experience: [0, [Validators.required, Validators.min(0)]],
+      };
+    }
+
+    if (this.data.type === 'subject') {
+      return {
+        name: ['', Validators.required],
+        hours: [0, [Validators.required, Validators.min(1)]],
+      };
+    }
+
+    if (this.data.type === 'load') {
+      return {
+        teacher: ['', Validators.required],
+        subject: ['', Validators.required],
+        group: ['', Validators.required],
+        type: ['lecture', Validators.required],
+      };
+    }
+
+    return {};
+  }
+
+  loadEntityById(id: string) {
+    this.loading = true;
+
+    let service: any | null = null;
+
+    if (this.data.type === 'teacher') {
+      service = this.teachersService;
+    } else if (this.data.type === 'subject') {
+      service = this.subjectsService;
+    } else if (this.data.type === 'load') {
+      service = this.loadsService;
+    }
+
+    if (!service) {
+      this.snackBar.open(`Unknown entity type: ${this.data.type}`, 'Close', { duration: 3000 });
+      this.dialogRef.close();
+      return;
+    }
+
+    (service.getById(id) as import('rxjs').Observable<any>).subscribe({
+      next: (entity) => {
+        this.form.patchValue(entity);
+        this.loading = false;
+      },
+      error: () => {
+        this.snackBar.open(`Failed to load ${this.data.type} data.`, 'Close', { duration: 3000 });
+        this.dialogRef.close();
+      }
+    });
+  }
+
+  onSubmit() {
+    if (this.form.invalid) return;
+
+    const value = this.form.value;
+
+    const duplicate = this.data.existing?.some((item) => {
+      if (this.data.type === 'teacher') {
+        return (
+          item.firstName?.toLowerCase() === value.firstName?.toLowerCase() &&
+          item.lastName?.toLowerCase() === value.lastName?.toLowerCase() &&
+          (!this.isEditMode || item._id !== this.data.entity?._id)
+        );
+      }
+
+      if (this.data.type === 'subject') {
+        return (
+          item.name?.toLowerCase() === value.name?.toLowerCase() &&
+          (!this.isEditMode || item._id !== this.data.entity?._id)
+        );
+      }
+
+      if (this.data.type === 'load') {
+        return (
+          item.teacher === value.teacher &&
+          item.subject === value.subject &&
+          item.group?.toLowerCase() === value.group?.toLowerCase() &&
+          (!this.isEditMode || item._id !== this.data.entity?._id)
+        );
+      }
+
+      return false;
+    });
+
+    if (duplicate) {
+      this.snackBar.open(`${this.data.type} already exists.`, 'Close', { duration: 3000 });
+      return;
+    }
+
+    this.dialogRef.close(value);
+
+    this.snackBar.open(
+      `${this.capitalize(this.data.type)} ${this.isEditMode ? 'updated' : 'created'} successfully!`,
+      'Close',
+      { duration: 3000 }
+    );
+  }
+
+  onCancel() {
+    this.dialogRef.close(null);
+  }
+
+  private capitalize(str: string) {
+    return str.charAt(0).toUpperCase() + str.slice(1);
+  }
+}

--- a/src/styles/_shared-ui.mixins.scss
+++ b/src/styles/_shared-ui.mixins.scss
@@ -1,0 +1,65 @@
+@mixin auth-card {
+  max-width: 560px;
+  margin: 0 auto 24px;
+  padding: 24px;
+  border-radius: 16px;
+  background: #fff;
+  box-shadow:
+    0 8px 24px rgba(0, 0, 0, .08),
+    0 2px 8px rgba(0, 0, 0, .04);
+
+  display: grid;
+  gap: 16px;
+  animation: pop .16s ease-out;
+}
+
+@mixin auth-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 560px;
+  margin: 16px auto 8px;
+  padding: 0 8px;
+
+  span {
+    font-weight: 600;
+    font-size: 22px;
+  }
+
+  .auth-link {
+    font-size: 14px;
+    color: #5e6ad2;
+    text-decoration: none;
+    opacity: .9;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+@mixin row-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+
+  @media (max-width: 640px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+@mixin form-error {
+  color: #c62828;
+  margin-top: 4px;
+}
+
+@keyframes pop {
+  from {
+    transform: translateY(6px);
+    opacity: 0;
+  }
+  to {
+    transform: none;
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
### Description

This PR introduces reusable shared UI components and integrates them into the main feature modules.
The goal is to reduce duplication and standardize the look & feel of forms, dialogs, and tables across the application.

### Implemented changes

**1. DataTableComponent**

 - Wrapper around `MatTable` with built-in `Paginator`, `Sort`, progress bar, and action buttons.

 - Supports dynamic column configuration, custom cell rendering, and row click events.

**2. EntityFormDialogComponent**

-  Generic form dialog for` create/edit` actions.

-  Currently supports Teacher, Subject, and Load entities.

-  Handles duplicate validation, form validation, and snackBar messages.

**3. ConfirmDialogComponent**

-  Simple confirmation modal for delete actions.

**4. Integration**

-  Replaced entity-specific dialogs with **EntityFormDialogComponent** in Teachers, Subjects, and Loads modules.

-  Updated table usage in all modules to use **DataTableComponent**.

-  Connected confirmation flows to **ConfirmDialogComponent**.

### Acceptance Criteria

-  Components reusable across **Teachers, Subjects, Loads**.

-  All `create/edit/delete` actions work with new dialogs.

-  **DataTable** supports pagination, sorting, and action buttons consistently.

### Related issue

Closes #15