### PR TITLE
feat(home): add dashboard cards with counters and quick navigation

### DIFF
--- a/src/app/features/dashboard/pages/home/home.component.html
+++ b/src/app/features/dashboard/pages/home/home.component.html
@@ -1,2 +1,19 @@
-<p>home works!</p>
-<p><strong>API status:</strong> {{ apiStatus }}</p>
+<div class="dashboard">
+  <mat-card class="card" (click)="navigate('/lecturers')">
+    <mat-card-title>Teachers</mat-card-title>
+    <mat-card-content>{{ teachersCount }}</mat-card-content>
+    <button mat-button color="primary">View Teachers</button>
+  </mat-card>
+
+  <mat-card class="card" (click)="navigate('/subjects')">
+    <mat-card-title>Subjects</mat-card-title>
+    <mat-card-content>{{ subjectsCount }}</mat-card-content>
+    <button mat-button color="primary">View Subjects</button>
+  </mat-card>
+
+  <mat-card class="card" (click)="navigate('/loads')">
+    <mat-card-title>Loads</mat-card-title>
+    <mat-card-content>{{ loadsCount }}</mat-card-content>
+    <button mat-button color="primary">View Loads</button>
+  </mat-card>
+</div>

--- a/src/app/features/dashboard/pages/home/home.component.scss
+++ b/src/app/features/dashboard/pages/home/home.component.scss
@@ -1,0 +1,21 @@
+.dashboard {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 20px;
+  padding: 20px;
+}
+
+.card {
+  text-align: center;
+  cursor: pointer;
+  transition: transform 0.2s ease-in-out;
+
+  &:hover {
+    transform: scale(1.03);
+  }
+
+  mat-card-content {
+    font-size: 2rem;
+    margin: 10px 0;
+  }
+}

--- a/src/app/features/dashboard/pages/home/home.component.ts
+++ b/src/app/features/dashboard/pages/home/home.component.ts
@@ -1,23 +1,40 @@
-import { Component, inject } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ApiClientService } from '../../../../core/api-client.service';
+import { Router } from '@angular/router';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { TeachersService } from '../../../teachers/services/teachers.service';
+import { SubjectsService } from '../../../subjects/services/subjects.service';
+import { LoadsService } from '../../../loads/services/loads.service';
 
 @Component({
-  selector: 'app-home',
   standalone: true,
-  imports: [CommonModule],
+  selector: 'app-home',
+  imports: [CommonModule, MatCardModule, MatButtonModule],
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.scss']
 })
+export class HomeComponent implements OnInit {
+  teachersCount = 0;
+  subjectsCount = 0;
+  loadsCount = 0;
 
-export class HomeComponent {
-  private api = inject(ApiClientService);
-  apiStatus = "checking...";
-  
+  private teachersService = inject(TeachersService);
+  private subjectsService = inject(SubjectsService);
+  private loadsService = inject(LoadsService);
+  private router = inject(Router);
+
   ngOnInit() {
-    this.api.get<{ message: string }>('/health').subscribe({
-      next: (r) => this.apiStatus = r.message,
-      error: () => this.apiStatus = 'API unavailable',
-    });
+    this.loadCounts();
+  }
+
+  loadCounts() {
+    this.teachersService.getAll().subscribe(data => this.teachersCount = data.length);
+    this.subjectsService.getAll().subscribe(data => this.subjectsCount = data.length);
+    this.loadsService.getAll().subscribe(data => this.loadsCount = data.length);
+  }
+
+  navigate(path: string) {
+    this.router.navigate([path]);
   }
 }


### PR DESCRIPTION
### Description
Implemented dashboard enhancements on the Home page:

- Added **cards** for Teachers, Subjects, and Loads.
- Each card shows the **current count** of entities from the API.
- Added **quick navigation links** to respective list pages.
- Responsive layout with hover effect.

### Acceptance Criteria
- [x] Teachers, Subjects, Loads counts are fetched from backend.
- [x] Cards navigate to /lecturers, /subjects, /loads.
- [x] Layout is responsive and user-friendly.

### Related Issue
Closes #17