### PR TITLE
feat(loads): add year field & filter in UI

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,19 +1,39 @@
-:host { display: block; }
-.app-container { height: 100vh; }
-.app-main { padding: 16px; }
-.spacer { flex: 1 1 auto; }
-.title { font-weight: 600; margin-left: 8px; }
+:host { 
+  display: block; 
+}
+.app-container { 
+  height: 100vh; 
+}
+.app-main { 
+  padding: 16px; 
+}
+.spacer { 
+  flex: 1 1 auto; 
+}
+.title { 
+  font-weight: 600; 
+  margin-left: 8px; 
+}
 
 mat-nav-list a {
   display: flex;
   align-items: center;
   gap: 8px;
+
+  &:hover { 
+    color: #1976d2; 
+  }
 }
 
 mat-icon {
   font-size: 20px;
 }
 
-.active { font-weight: 600; color: #1976d2; }
+.active { 
+  font-weight: 600; 
+  color: #1976d2; 
+}
 
-@media (min-width: 960px) { .hide-desktop { display: none; } }
+@media (min-width: 960px) { 
+  .hide-desktop { display: none; } 
+}

--- a/src/app/features/loads/pages/loads/loads.component.html
+++ b/src/app/features/loads/pages/loads/loads.component.html
@@ -1,9 +1,41 @@
 <h2 class="page-title">Teaching Loads</h2>
 
-<div class="toolbar">
-  <button mat-flat-button color="primary" (click)="openCreateDialog()">
-    + Add Load
-  </button>
+<div class="filters">
+  <div class="filters-row">
+    <mat-form-field appearance="outline">
+      <mat-label>Year</mat-label>
+      <input
+        matInput
+        type="number"
+        placeholder="Enter year"
+        [(ngModel)]="selectedYear"
+        (ngModelChange)="loadLoads()"
+        [min]="minYear"
+        [max]="maxYear"
+      />
+    </mat-form-field>
+
+    <mat-form-field appearance="outline">
+      <mat-label>Type</mat-label>
+      <mat-select [(ngModel)]="selectedType" (selectionChange)="loadLoads()">
+        <mat-option [value]="null">All</mat-option>
+        <mat-option value="lecture">Lecture</mat-option>
+        <mat-option value="practice">Practice</mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <button
+      mat-stroked-button
+      color="primary"
+      (click)="selectedYear = null; selectedType = null; loadLoads()"
+    >
+      Reset Filters
+    </button>
+
+    <button mat-flat-button color="primary" (click)="openCreateDialog()">
+      + Add Load
+    </button>
+  </div>
 </div>
 
 <app-data-table

--- a/src/app/features/loads/pages/loads/loads.component.scss
+++ b/src/app/features/loads/pages/loads/loads.component.scss
@@ -1,15 +1,42 @@
+@use '../../../../../styles/shared-ui.mixins' as *;
+
 .page-title {
-  font-size: 20px;
-  font-weight: 600;
-  margin: 16px 0;
+  @include auth-title;
+  max-width: 100%;
+  padding: 0 16px;
+
+  span {
+    font-size: 24px;
+  }
 }
 
-.toolbar {
-  display: flex;
-  justify-content: flex-end;
-  margin-bottom: 12px;
+.filters {
+  margin: 16px auto;
+  max-width: 1200px;
+  padding: 0 16px;
+
+  .filters-row {
+    display: flex;
+    align-items: stretch;
+    gap: 16px;
+    flex-wrap: wrap;
+
+    mat-form-field {
+      min-width: 160px;
+      flex: 1 1 auto;
+
+      @include form-field-style;
+    }
+  }
 
   button {
-    font-weight: 500;
+    @include primary-button;
   }
+}
+
+app-data-table {
+  display: block;
+  margin: 0 auto;
+  max-width: 1200px;
+  padding: 0 16px;
 }

--- a/src/app/features/loads/pages/loads/loads.component.ts
+++ b/src/app/features/loads/pages/loads/loads.component.ts
@@ -8,11 +8,15 @@ import { MatDialog } from '@angular/material/dialog';
 import { EntityFormDialogComponent } from '../../../../shared/components/entity-form-dialog/entity-form-dialog.component';
 import { ConfirmDialogComponent } from '../../../../shared/components/confirm-dialog/confirm-dialog.component';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { FormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { MatInputModule } from '@angular/material/input';
 
 @Component({
   standalone: true,
   selector: 'app-loads',
-  imports: [CommonModule, DataTableComponent],
+  imports: [CommonModule, DataTableComponent, FormsModule, MatFormFieldModule, MatSelectModule, MatInputModule],
   templateUrl: './loads.component.html',
   styleUrls: ['./loads.component.scss'],
 })
@@ -23,6 +27,12 @@ export class LoadsComponent implements OnInit {
   pageSize = 10;
   loading = false;
 
+  selectedYear: number | null = null;
+  selectedType: string | null = null;
+
+  minYear = 2015;
+  maxYear = new Date().getFullYear();
+  
   columns: DataTableColumn[] = [
     { 
       key: 'teacher', 
@@ -35,7 +45,8 @@ export class LoadsComponent implements OnInit {
       cell: (row) => row.subject?.name || '' 
     },
     { key: 'group', header: 'Group' },
-    { key: 'type', header: 'Type' }
+    { key: 'type', header: 'Type' },
+    { key: 'year', header: 'Year' }
   ];
 
   constructor(
@@ -49,11 +60,30 @@ export class LoadsComponent implements OnInit {
   }
 
   loadLoads() {
+    if (this.selectedYear && (this.selectedYear < 2015 || this.selectedYear > new Date().getFullYear())) {
+        this.snackBar.open(
+          `Year must be between 2015 and ${new Date().getFullYear()}.`,
+          'Close',
+          { duration: 3000 }
+        );
+        this.selectedYear = null;
+      }
+
     this.loading = true;
     this.loadsService.getAll().subscribe({
       next: (data) => {
-        this.rows = data;
-        this.total = data.length;
+        let filtered = data;
+
+        if (this.selectedYear) {
+          filtered = filtered.filter((l) => l.year === this.selectedYear);
+        }
+
+        if (this.selectedType) {
+          filtered = filtered.filter((l) => l.type === this.selectedType);
+        }
+
+        this.rows = filtered;
+        this.total = filtered.length;
         this.loading = false;
       },
       error: () => {

--- a/src/app/features/loads/services/loads.service.ts
+++ b/src/app/features/loads/services/loads.service.ts
@@ -8,6 +8,7 @@ export interface Load {
   subject: string;
   group: string;
   type: string;
+  year: number;
 }
 
 @Injectable({ providedIn: 'root' })

--- a/src/app/features/subjects/pages/subjects/subjects.component.scss
+++ b/src/app/features/subjects/pages/subjects/subjects.component.scss
@@ -1,8 +1,13 @@
+@use '../../../../../styles/shared-ui.mixins' as *;
+
 .page-title {
-  font-size: 20px;
-  font-weight: 600;
-  margin-bottom: 16px;
-  color: #333;
+  @include auth-title;
+  max-width: 100%;
+  padding: 0 16px;
+
+  span {
+    font-size: 24px;
+  }
 }
 
 .toolbar {
@@ -11,6 +16,8 @@
   margin-bottom: 12px;
 
   button {
+    @include primary-button;
+    min-width: 160px;
     font-weight: 500;
   }
 }

--- a/src/app/features/teachers/pages/teachers/teachers.component.scss
+++ b/src/app/features/teachers/pages/teachers/teachers.component.scss
@@ -1,6 +1,13 @@
+@use '../../../../../styles/shared-ui.mixins' as *;
+
 .page-title {
-  margin: 0 0 12px;
-  font-weight: 600;
+  @include auth-title;
+  max-width: 100%;
+  padding: 0 16px;
+
+  span {
+    font-size: 24px;
+  }
 }
 
 .toolbar {
@@ -9,6 +16,8 @@
   margin-bottom: 12px;
 
   button {
+    @include primary-button;
+    min-width: 160px;
     font-weight: 500;
   }
 }

--- a/src/app/shared/components/data-table/data-table.component.html
+++ b/src/app/shared/components/data-table/data-table.component.html
@@ -36,7 +36,7 @@
 
     <tr class="no-data-row" *ngIf="!loading && data.length === 0">
       <td [attr.colspan]="displayedColumns.length" class="no-data">
-        Немає даних для відображення.
+        No data available
       </td>
     </tr>
   </table>

--- a/src/app/shared/components/data-table/data-table.component.scss
+++ b/src/app/shared/components/data-table/data-table.component.scss
@@ -38,7 +38,7 @@ th.mat-mdc-header-cell {
 
 tr.empty td {
   text-align: center;
-  color: #666;
+  color: #5e6ad2;
   padding: 24px 12px;
   font-style: italic;
 }

--- a/src/app/shared/components/data-table/data-table.component.ts
+++ b/src/app/shared/components/data-table/data-table.component.ts
@@ -60,9 +60,9 @@ export class DataTableComponent implements OnChanges {
   @ViewChild(MatSort) sortRef?: MatSort;
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (this.columns && Array.isArray(this.columns) && this.columns.length > 0) {
+    if (this.columns?.length) {
       this.displayedColumns = this.columns.map((c) => c.key);
-      if (this.showActions) {
+      if (this.showActions && !this.displayedColumns.includes('actions')) {
         this.displayedColumns.push('actions');
       }
 

--- a/src/app/shared/components/entity-form-dialog/entity-form-dialog.component.html
+++ b/src/app/shared/components/entity-form-dialog/entity-form-dialog.component.html
@@ -62,7 +62,7 @@
       <mat-label>Teacher</mat-label>
       <mat-select formControlName="teacher">
         <mat-option *ngFor="let t of teachers" [value]="t._id">
-          {{ t.firstName }} {{ t.lastName }}
+          {{ t.lastName }} {{ t.firstName }}
         </mat-option>
       </mat-select>
     </mat-form-field>
@@ -87,6 +87,11 @@
         <mat-option value="lecture">Lecture</mat-option>
         <mat-option value="practice">Practice</mat-option>
       </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Year</mat-label>
+      <input matInput type="number" formControlName="year" />
     </mat-form-field>
   </ng-container>
 

--- a/src/app/shared/components/entity-form-dialog/entity-form-dialog.component.ts
+++ b/src/app/shared/components/entity-form-dialog/entity-form-dialog.component.ts
@@ -8,8 +8,8 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 
-import { TeachersService } from '../../../features/teachers/services/teachers.service';
-import { SubjectsService } from '../../../features/subjects/services/subjects.service';
+import { Teacher, TeachersService } from '../../../features/teachers/services/teachers.service';
+import { Subject, SubjectsService } from '../../../features/subjects/services/subjects.service';
 import { LoadsService } from '../../../features/loads/services/loads.service';
 
 @Component({
@@ -32,8 +32,13 @@ export class EntityFormDialogComponent {
   form: FormGroup;
   isEditMode = false;
   loading = false;
-  teachers: any[] = [];
-  subjects: any[] = [];
+  teachers: Teacher[] = [];
+  subjects: Subject[] = [];
+  entityLabels: { [key: string]: string } = {
+    teacher: 'Teacher',
+    subject: 'Subject',
+    load: 'Load'
+  };
 
   constructor(
     private dialogRef: MatDialogRef<EntityFormDialogComponent>,
@@ -101,6 +106,7 @@ export class EntityFormDialogComponent {
         subject: ['', Validators.required],
         group: ['', Validators.required],
         type: ['lecture', Validators.required],
+        year: [new Date().getFullYear(), [Validators.required, Validators.min(2000)]],
       };
     }
 
@@ -164,6 +170,7 @@ export class EntityFormDialogComponent {
           item.teacher === value.teacher &&
           item.subject === value.subject &&
           item.group?.toLowerCase() === value.group?.toLowerCase() &&
+          item.year === value.year &&
           (!this.isEditMode || item._id !== this.data.entity?._id)
         );
       }
@@ -179,7 +186,7 @@ export class EntityFormDialogComponent {
     this.dialogRef.close(value);
 
     this.snackBar.open(
-      `${this.capitalize(this.data.type)} ${this.isEditMode ? 'updated' : 'created'} successfully!`,
+      `${this.entityLabels[this.data.type]} ${this.isEditMode ? 'updated' : 'created'} successfully!`,
       'Close',
       { duration: 3000 }
     );

--- a/src/styles/_shared-ui.mixins.scss
+++ b/src/styles/_shared-ui.mixins.scss
@@ -53,6 +53,89 @@
   margin-top: 4px;
 }
 
+@mixin primary-button {
+  height: 56px;
+  padding: 0 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  border: 2px solid #1976d2;
+  background-color: #fff;
+  color: #1976d2;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.3s ease;
+
+  &:hover {
+    background-color: #1976d2;
+    color: #fff;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, .1);
+  }
+
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 6px rgba(25, 118, 210, 0.6);
+  }
+}
+
+@mixin primary-input {
+  border: 2px solid #1976d2;
+  border-radius: 8px;
+  padding: 8px 12px;
+  height: 30px;
+  width: 100%;
+  transition: all 0.3s ease;
+
+  &:focus {
+    outline: none;
+    border-color: #1976d2;
+    box-shadow: 0 0 5px rgba(25, 118, 210, 0.5);
+  }
+}
+
+@mixin form-field-style {
+  ::ng-deep .mat-mdc-text-field-wrapper {
+    border: 2px solid #1976d2;
+    border-radius: 8px;
+    height: 56px;
+    display: flex;
+    align-items: center;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+    &:hover {
+      border-color: darken(#1976d2, 10%);
+    }
+
+    &.mdc-text-field--focused {
+      border-color: #1565c0;
+      box-shadow: 0 0 6px rgba(25, 118, 210, 0.4);
+    }
+  }
+
+  ::ng-deep input.mat-mdc-input-element {
+    height: 100%;
+    padding: 0 12px;
+    font-size: 16px;
+    font-weight: 500;
+    box-sizing: border-box;
+  }
+
+  ::ng-deep .mat-mdc-select-trigger {
+    height: 56px;
+    display: flex;
+    align-items: center;
+    padding: 0 12px;
+    font-size: 16px;
+    font-weight: 500;
+  }
+
+  ::ng-deep .mat-mdc-floating-label {
+    color: #1976d2 !important;
+    font-weight: 500;
+  }
+}
+
 @keyframes pop {
   from {
     transform: translateY(6px);


### PR DESCRIPTION
- Added year field to `create/edit` Load form (EntityFormDialog)  
- Default year set to current year  
- Implemented filtering by year and type on `/loads` page  
- Passed selected year as query param to API  
- Displayed Year column in **DataTable**  
- Updated UI styles for filters and buttons

Closes #19 