### PR TITLE
feat(data-table): implement client-side pagination support

### DIFF
--- a/src/app/features/loads/pages/loads/loads.component.ts
+++ b/src/app/features/loads/pages/loads/loads.component.ts
@@ -21,11 +21,18 @@ import { MatInputModule } from '@angular/material/input';
   styleUrls: ['./loads.component.scss'],
 })
 export class LoadsComponent implements OnInit {
+  allLoads: Load[] = [];
   rows: Load[] = [];
   total = 0;
   pageIndex = 0;
   pageSize = 10;
   loading = false;
+
+  updateRows() {
+    const start = this.pageIndex * this.pageSize;
+    const end = start + this.pageSize;
+    this.rows = this.allLoads.slice(start, end);
+  }
 
   selectedYear: number | null = null;
   selectedType: string | null = null;
@@ -82,8 +89,9 @@ export class LoadsComponent implements OnInit {
           filtered = filtered.filter((l) => l.type === this.selectedType);
         }
 
-        this.rows = filtered;
+        this.allLoads = filtered;
         this.total = filtered.length;
+        this.updateRows();
         this.loading = false;
       },
       error: () => {
@@ -158,7 +166,9 @@ export class LoadsComponent implements OnInit {
   }
 
   onPage(event: PageEvent) {
-    console.log('pagination event', event);
+    this.pageIndex = event.pageIndex;
+    this.pageSize = event.pageSize;
+    this.updateRows();
   }
 
   onSort(event: Sort) {

--- a/src/app/features/subjects/pages/subjects/subjects.component.ts
+++ b/src/app/features/subjects/pages/subjects/subjects.component.ts
@@ -17,6 +17,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
   styleUrls: ['./subjects.component.scss'],
 })
 export class SubjectsComponent implements OnInit {
+  allSubjects: Subject[] = [];
   rows: Subject[] = [];
   total = 0;
   pageIndex = 0;
@@ -42,11 +43,12 @@ export class SubjectsComponent implements OnInit {
     this.loading = true;
     this.subjectsService.getAll().subscribe({
       next: (data) => {
-        this.rows = data;
+        this.allSubjects = data;
         this.total = data.length;
+        this.updateRows();
         this.loading = false;
       },
-      error: (err) => {
+      error: () => {
         this.snackBar.open('Failed to load subjects', 'Close', { duration: 3000 });
         this.loading = false;
       }
@@ -125,8 +127,16 @@ export class SubjectsComponent implements OnInit {
     console.log('row clicked', row);
   }
 
+  updateRows() {
+    const start = this.pageIndex * this.pageSize;
+    const end = start + this.pageSize;
+    this.rows = this.allSubjects.slice(start, end);
+  }
+
   onPage(event: PageEvent) {
-    console.log('pagination event', event);
+    this.pageIndex = event.pageIndex;
+    this.pageSize = event.pageSize;
+    this.updateRows();
   }
 
   onSort(event: Sort) {

--- a/src/app/features/teachers/pages/teachers/teachers.component.ts
+++ b/src/app/features/teachers/pages/teachers/teachers.component.ts
@@ -20,12 +20,18 @@ import { ConfirmDialogComponent } from '../../../../shared/components/confirm-di
   styleUrls: ['./teachers.component.scss'],
 })
 export class TeachersComponent implements OnInit {
-
+  allTeachers: Teacher[] = [];
   rows: Teacher[] = [];
   total = 0;
   pageIndex = 0;
   pageSize = 10;
   loading = false;
+
+  updateRows() {
+    const start = this.pageIndex * this.pageSize;
+    const end = start + this.pageSize;
+    this.rows = this.allTeachers.slice(start, end);
+  }
 
   columns: DataTableColumn[] = [
     { key: 'firstName', header: 'First Name' },
@@ -49,8 +55,9 @@ export class TeachersComponent implements OnInit {
     this.loading = true;
     this.teachersService.getAll().subscribe({
       next: (teachers) => {
-        this.rows = teachers;
+        this.allTeachers = teachers;
         this.total = teachers.length;
+        this.updateRows();
         this.loading = false;
       },
       error: (err) => {
@@ -114,7 +121,9 @@ export class TeachersComponent implements OnInit {
   }
 
   onPage(event: PageEvent) {
-    console.log('pagination event', event);
+    this.pageIndex = event.pageIndex;
+    this.pageSize = event.pageSize;
+    this.updateRows();
   }
 
   onSort(event: Sort) {


### PR DESCRIPTION
### Description

Implement client-side pagination in **DataTable** component.
Now only the visible rows are rendered based on `pageIndex` and `pageSize`, improving performance and respecting paginator settings.

### Changes

- Added slicing logic in **Teachers,** **Subjects**, and Loads components.

- Updated `onPage` handler to recalculate displayed rows.

- Ensured pagination works consistently across all entities.

### Acceptance Criteria

-  Changing items per page updates rows shown.

-  Navigating between pages updates dataset correctly.

-  Pagination works consistently for **Teachers, Subjects, and Loads**.

Closes #21 
